### PR TITLE
Security fixes

### DIFF
--- a/admin/staff_del_confirm.php
+++ b/admin/staff_del_confirm.php
@@ -23,8 +23,7 @@
   /**
    * Checking for query string. Go back to $returnLocation if none found.
    */
-  if (count($_GET) == 0 || !is_numeric($_GET["id_member"])
-    || empty($_GET["surname1"]) || empty($_GET["first_name"]))
+  if (count($_GET) == 0 || !is_numeric($_GET["id_member"]))
   {
     header("Location: " . $returnLocation);
     exit();
@@ -43,10 +42,35 @@
    * Retrieving get vars
    */
   $idMember = intval($_GET["id_member"]);
-  $surname1 = Check::safeText($_GET["surname1"]);
-  $surname2 = Check::safeText($_GET["surname2"]);
-  $firstName = Check::safeText($_GET["first_name"]);
 
+  if( $idMember == $_SESSION['auth']['member_user'] )
+  {
+	FlashMsg::add(_("You can't delete yourself!"), OPEN_MSG_ERROR);
+    header("Location: " . $returnLocation);
+    exit(); 
+  }
+  
+  require_once("../model/Query/Staff.php");
+  $staffQ = new Query_Staff();
+  
+  if ( !$staffQ->select($idMember) )
+  {
+    $staffQ->close();
+
+    FlashMsg::add(_("That staff member does not exist."), OPEN_MSG_ERROR);
+    header("Location: " . $returnLocation);
+    exit();
+  }
+
+  $staff = $staffQ->fetch();
+  $staffQ->close();
+  unset($staffQ);
+
+  $firstName = $staff->getFirstName();
+  $surname1 = $staff->getSurname1();
+  $surname2 = $staff->getSurname2();
+  unset($staff);
+  
   /**
    * Show page
    */
@@ -71,7 +95,7 @@
 
   $tbody = array();
 
-  $tbody[] = Msg::warning(sprintf(_("Are you sure you want to delete staff member, %s %s %s?"), $firstName, $surname1, $surname2));
+  $tbody[] = Msg::warning(sprintf(_("Are you sure you want to delete staff member: %s %s %s?"), $firstName, $surname1, $surname2));
 
   $tbody[] = Form::hidden("id_member", $idMember);
 

--- a/admin/staff_list.php
+++ b/admin/staff_list.php
@@ -165,10 +165,7 @@
         HTML::image('../img/action_delete.png', _("delete")),
         '../admin/staff_del_confirm.php',
         array(
-          'id_member' => $staff->getIdMember(),
-          'surname1' => $staff->getSurname1(),
-          'surname2' => $staff->getSurname2(),
-          'first_name' => $staff->getFirstName()
+          'id_member' => $staff->getIdMember()
         )
       );
     } // end if

--- a/admin/user_list.php
+++ b/admin/user_list.php
@@ -152,8 +152,7 @@
         HTML::image('../img/action_delete.png', _("delete")),
         '../admin/user_del_confirm.php',
         array(
-          'id_user' => $user->getIdUser(),
-          'login' => $user->getLogin()
+          'id_user' => $user->getIdUser()
         )
       );
     }

--- a/config/session_info.php
+++ b/config/session_info.php
@@ -22,7 +22,8 @@
    */
   ini_set('session.use_cookies', 1); // cookies will be used for propagation of the session ID
   ini_set('session.use_only_cookies', 1); // a session ID passed in the URL to the script will be discarded
-
+  ini_set('session.cookie_httponly', 1 );
+  
   session_name("OpenClinic");
   session_cache_limiter("nocache");
   session_start();


### PR DESCRIPTION
. Fixed CSRF + Insecure Direct Object References in user delete & staff_member delete.
    User delete: With username GET parameter adulterated, an admin could delete an user which id doesn't match that username. Eg, admin think that he is deleting a trash user but, indeed, the id is of other admin .. or could be his own id !.
   Member delete: IDEM "user delete" but with first name and surnames parameters.
    Aditional:  the admin could delete himself, no longer now. 

. Session hijacking: Httponly flag added to session cookies.